### PR TITLE
fix: correct h1 css selector

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -223,7 +223,7 @@
 
   From: https://www.tpgi.com/the-anatomy-of-visually-hidden/
 */
-#adbc-driver-foundry-driver-documentation>h1 {
+#adbc-driver-foundry-documentation>h1 {
     clip: rect(0 0 0 0);
     clip-path: inset(50%);
     height: 1px;


### PR DESCRIPTION
Re-hides the h1 element on the index page.