### PR TITLE
chore: remove last modified dates from pages

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -218,3 +218,14 @@ def setup(app):
     for variant in custom_badge_variants:
         role_name = f"badge-{variant}"
         app.add_role(role_name, badge_role)
+
+    # Remove last_updated dates from pages.
+    #
+    # When we added sphinx-sitemap last modified dates started showing up at the
+    # bottom of every page. sphinx-sitemap uses sphinx-last-updated-by-git which
+    # turns on `html_last_updated_fmt and ignores what the user has set so we
+    # have to put a hook in to force it back to None at this phase of the build.
+    def reset_last_updated_fmt(app):
+        app.config.html_last_updated_fmt = None
+
+    app.connect("builder-inited", reset_last_updated_fmt)


### PR DESCRIPTION
Adding sphinx-sitemap caused last modification dates to show up on our pages. We don't want these and, even if we did, the dates are wrong for an unknown reason. This adds a hook to remove them which was necessary because the plugin `sphinx-sitemap` uses overrides any static config we might set. See comment in commit for more info.

I've tested that,

1. This removes the dates
2. It does not remove the last mod dates from our sitemaps 