### PR TITLE
feat: a link to github org in header bar

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -109,9 +109,7 @@ html_theme_options = {
     "toc_title": "Contents",
     "repo_url": "https://github.com/adbc-drivers",
     "repo_name": "adbc-drivers",
-    "icon":{
-        "repo": "fontawesome/brands/github"
-    }
+    "icon": {"repo": "fontawesome/brands/github"},
 }
 
 # -- Options for Intersphinx -------------------------------------------------


### PR DESCRIPTION
Uses (abuses?) our themes built-in ability to show a link to the the foundry GitHub org in the header of the page.

Closes #40 