### PR TITLE
fix: update clickhouse issues url to clickhouse org repo

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -175,7 +175,7 @@ driver_header_links_config = {
         {"url": "https://github.com/adbc-drivers/bigquery", "label": "GitHub"},
     ],
     "clickhouse": [
-        {"url": "https://github.com/adbc-drivers/clickhouse", "label": "GitHub"},
+        {"url": "https://github.com/ClickHouse/adbc_clickhouse", "label": "GitHub"},
     ],
     "databricks": [
         {"url": "https://github.com/adbc-drivers/databricks", "label": "GitHub"},


### PR DESCRIPTION
We're going to disable issues on the adbc-drivers/clickhouse repo so we should update this link.