### PR TITLE
fix: minor fixes

### DIFF
--- a/drivers/mssql/v1.4.1.md
+++ b/drivers/mssql/v1.4.1.md
@@ -1124,6 +1124,7 @@ This driver was tested on:
 
 To see documentation for previous versions of this driver, see the following:
 
+- [v1.4.0](./v1.4.0.md)
 - [v1.3.1](./v1.3.1.md)
 - [v1.3.0](./v1.3.0.md)
 - [v1.2.0](./v1.2.0.md)

--- a/drivers/redshift/index.md
+++ b/drivers/redshift/index.md
@@ -1000,6 +1000,8 @@ TIMESTAMPTZ
 
 To see documentation for previous versions of this driver, see the following:
 
+- [v1.3.0](./v1.3.0.md)
+- [v1.2.1](./v1.2.1.md)
 - [v1.1.0](./v1.1.0.md)
 - [v1.0.0](./v1.0.0.md)
 

--- a/drivers/redshift/v1.4.0.md
+++ b/drivers/redshift/v1.4.0.md
@@ -977,6 +977,8 @@ TIMESTAMPTZ
 
 To see documentation for previous versions of this driver, see the following:
 
+- [v1.3.0](./v1.3.0.md)
+- [v1.2.1](./v1.2.1.md)
 - [v1.1.0](./v1.1.0.md)
 - [v1.0.0](./v1.0.0.md)
 

--- a/drivers/trino/index.md
+++ b/drivers/trino/index.md
@@ -210,6 +210,18 @@ The driver also supports the Trino DSN format (see [Go Trino Client documentatio
 <tr>
 <td style="text-align: left;">
 
+ARRAY
+
+</td>
+<td style="text-align: center;">
+
+list
+
+</td>
+</tr>
+<tr>
+<td style="text-align: left;">
+
 BIGINT
 
 </td>
@@ -482,7 +494,46 @@ DATE
 decimal128
 
 </td>
-<td colspan="2" style="text-align: center;">
+<td style="text-align: center;">
+
+DECIMAL
+
+</td>
+<td style="text-align: center;">
+
+DECIMAL, NUMERIC ⚠️ [^1]
+
+</td>
+</tr>
+<tr>
+<td style="text-align: left;">
+
+decimal32
+
+</td>
+<td style="text-align: center;">
+
+(NA/not tested)
+
+</td>
+<td style="text-align: center;">
+
+DECIMAL
+
+</td>
+</tr>
+<tr>
+<td style="text-align: left;">
+
+decimal64
+
+</td>
+<td style="text-align: center;">
+
+(NA/not tested)
+
+</td>
+<td style="text-align: center;">
 
 DECIMAL
 
@@ -621,7 +672,7 @@ string
 </td>
 <td style="text-align: center;">
 
-IPADDRESS, VARCHAR
+VARCHAR, IPADDRESS
 
 </td>
 <td style="text-align: center;">
@@ -812,6 +863,6 @@ To see documentation for previous versions of this driver, see the following:
 - [v0.2.0](./v0.2.0.md)
 - [v0.1.0](./v0.1.0.md)
 
-
+[^1]: Negative scales are not supported
 
 [trino]: https://trino.io/

--- a/drivers/trino/v0.5.0.md
+++ b/drivers/trino/v0.5.0.md
@@ -845,6 +845,7 @@ This driver was tested on:
 
 To see documentation for previous versions of this driver, see the following:
 
+- [v0.4.0](./v0.4.0.md)
 - [v0.3.1](./v0.3.1.md)
 - [v0.3.0](./v0.3.0.md)
 - [v0.2.0](./v0.2.0.md)


### PR DESCRIPTION
Some generated documents didn't include the links to the previous documentation.
Update trino index.md with latest docs