### PR TITLE
docs: update mysql docs for v0.5.0

### DIFF
--- a/drivers/mysql/changelog.md
+++ b/drivers/mysql/changelog.md
@@ -17,6 +17,13 @@
 
 # Changelog for MySQL/MariaDB Driver
 
+
+## v0.5.0 (2026-07-10)
+
+## New Features
+
+- add options to control zero datetime behavior
+
 ## v0.4.0 (2026-06-18)
 
 New features:

--- a/drivers/mysql/changelog.md
+++ b/drivers/mysql/changelog.md
@@ -22,7 +22,7 @@
 
 ## New Features
 
-- add options to control zero datetime behavior
+- Add option to control how date(time)s with zero components (`0000-00-00`) are read (either raising an error, or treating it as NULL)
 
 ## v0.4.0 (2026-06-18)
 

--- a/drivers/mysql/v0.5.0.md
+++ b/drivers/mysql/v0.5.0.md
@@ -15,20 +15,8 @@
 {}
 ---
 
-# MySQL/MariaDB
-
-:::{toctree}
-:maxdepth: 1
-:hidden:
-
-Changelog <changelog.md>
-v0.5.0 <v0.5.0.md>
-v0.4.0 <v0.4.0.md>
-v0.3.1 <v0.3.1.md>
-v0.3.0 <v0.3.0.md>
-v0.2.0 <v0.2.0.md>
-v0.1.0 <v0.1.0.md>
-:::
+(driver-mysql-v0.5.0)=
+# MySQL/MariaDB Driver v0.5.0
 
 [{badge-primary}`Driver Version|v0.5.0`](#driver-mysql-v0.5.0 "Permalink") {badge-secondary}`Release Date|2026-07-10` {badge-success}`Tested With|MySQL 9.4` {badge-success}`Tested With|MariaDB 12.2`
 


### PR DESCRIPTION
Generated automatically by https://github.com/adbc-drivers/docs.adbc-drivers.org/pull/109.